### PR TITLE
Fix rendering several tracks at the same time

### DIFF
--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/AssHandler.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/AssHandler.kt
@@ -175,6 +175,13 @@ class AssHandler(val useEffectsRenderer: Boolean) : Listener {
     }
 
     /**
+     * Reads a [dialogue] into the track of the given [trackId].
+     */
+    fun readTrackDialogue(dialogue: String, trackId: String?) {
+        availableTracks[trackId]?.readBuffer(dialogue)
+    }
+
+    /**
      * Retrieves the ID of the selected ASS track, if any.
      * @param tracks The selected tracks.
      * @return The ID of the selected ASS track, or null if none.

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/text/AssTrackOutput.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/text/AssTrackOutput.kt
@@ -24,9 +24,12 @@ class AssTrackOutput(
 
     private var currentLine = ""
 
+    private var trackId: String? = null
+
     override fun format(format: Format) {
         if (format.sampleMimeType == MimeTypes.TEXT_SSA || format.codecs == MimeTypes.TEXT_SSA) {
             isAss = true
+            trackId = format.id
         }
         delegate.format(format)
     }
@@ -69,7 +72,7 @@ class AssTrackOutput(
                 val start = timeUs.toAssTime()
                 val end = (timeUs + endUs).toAssTime()
                 val dialogue = "%s %s,%s,%s".format(lineType, start, end, remainder)
-                assHandler.track?.readBuffer(dialogue)
+                assHandler.readTrackDialogue(dialogue, trackId)
             }
         }
         delegate.sampleMetadata(timeUs, flags, size, offset, cryptoData)


### PR DESCRIPTION
There was a bug where the dialogues from all the subtitle tracks were added to the active track