### PR TITLE
Make libass load embed fonts

### DIFF
--- a/lib_ass_kt/src/main/cpp/AssKt.c
+++ b/lib_ass_kt/src/main/cpp/AssKt.c
@@ -18,6 +18,7 @@
 jlong nativeAssInit(JNIEnv* env, jclass clazz) {
     ASS_Library* assLibrary = ass_library_init();
     ass_set_fonts_dir(assLibrary, "/system/fonts");
+    ass_set_extract_fonts(assLibrary, 1);
     return (jlong) assLibrary;
 }
 


### PR DESCRIPTION
By default fonts embed into .ass files are not loaded. Instruct libass to do so.