### PR TITLE
Use ass_process_chunk when the overlay renderer is enabled

### DIFF
--- a/lib_ass_kt/src/main/cpp/AssKt.c
+++ b/lib_ass_kt/src/main/cpp/AssKt.c
@@ -130,6 +130,16 @@ void nativeAssTrackReadBuffer(JNIEnv* env, jclass clazz, jlong track, jbyteArray
     (*env)->ReleaseByteArrayElements(env, buffer, elements, 0);
 }
 
+void nativeAssTrackReadChunk(JNIEnv* env, jclass clazz, jlong track, jlong start, jlong duration, jbyteArray buffer, jint offset, jint length) {
+    jboolean isCopy;
+    jbyte* elements = (*env)->GetByteArrayElements(env, buffer, &isCopy);
+    if (elements == NULL) {
+        return;
+    }
+    ass_process_chunk((ASS_Track *) track, elements + offset, length, start, duration);
+    (*env)->ReleaseByteArrayElements(env, buffer, elements, 0);
+}
+
 void nativeAssTrackDeinit(JNIEnv* env, jclass clazz, jlong track) {
     ass_free_track((ASS_Track *) track);
 }
@@ -142,6 +152,7 @@ static JNINativeMethod trackMethodTable[] = {
         {"nativeAssTrackGetEvents", "(J)[Lio/github/peerless2012/ass/kt/ASSEvent;", (void*) nativeAssTrackGetEvents},
         {"nativeAssTrackClearEvents", "(J)V", (void*) nativeAssTrackClearEvents},
         {"nativeAssTrackReadBuffer", "(J[BII)V", (void*)nativeAssTrackReadBuffer},
+        {"nativeAssTrackReadChunk", "(JJJ[BII)V", (void*)nativeAssTrackReadChunk},
         {"nativeAssTrackDeinit", "(J)V", (void*)nativeAssTrackDeinit}
 };
 

--- a/lib_ass_kt/src/main/java/io/github/peerless2012/ass/kt/ASSTrack.kt
+++ b/lib_ass_kt/src/main/java/io/github/peerless2012/ass/kt/ASSTrack.kt
@@ -30,12 +30,13 @@ class ASSTrack(private val ass: Long) {
         external fun nativeAssTrackReadBuffer(track: Long, byteArray: ByteArray, offset: Int, length: Int)
 
         @JvmStatic
+        external fun nativeAssTrackReadChunk(track: Long, start: Long, duration: Long, byteArray: ByteArray, offset: Int, length: Int)
+
+        @JvmStatic
         external fun nativeAssTrackDeinit(track: Long)
     }
 
     public val nativeAssTrack = nativeAssTrackInit(ass)
-
-    private val hashCache = mutableSetOf<Int>()
 
     public fun getWidth(): Int {
         return nativeAssTrackGetWidth(nativeAssTrack)
@@ -50,21 +51,15 @@ class ASSTrack(private val ass: Long) {
     }
 
     public fun clearEvent() {
-        hashCache.clear()
         nativeAssTrackClearEvents(nativeAssTrack)
-    }
-
-    public fun readBuffer(line: String) {
-        val hash = line.hashCode()
-        if (hash in hashCache) return
-
-        hashCache.add(hash)
-        val array = line.encodeToByteArray()
-        nativeAssTrackReadBuffer(nativeAssTrack, array, 0, array.size)
     }
 
     public fun readBuffer(array: ByteArray, offset: Int = 0, length : Int = array.size) {
         nativeAssTrackReadBuffer(nativeAssTrack, array, offset, length)
+    }
+
+    public fun readChunk(start: Long, duration: Long, array: ByteArray, offset: Int = 0, length: Int = array.size) {
+        nativeAssTrackReadChunk(nativeAssTrack, start, duration, array, offset, length)
     }
 
     protected fun finalize() {

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/AssHandler.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/AssHandler.kt
@@ -153,7 +153,7 @@ class AssHandler(val useEffectsRenderer: Boolean) : Listener {
         createRenderIfNeeded()
 
         val track = ass.createTrack()
-        val header = AssHeaderParser.parse(format)
+        val header = AssHeaderParser.parse(format, useEffectsRenderer)
         track.readBuffer(header)
         availableTracks[format.id!!] = track
         return track
@@ -175,10 +175,17 @@ class AssHandler(val useEffectsRenderer: Boolean) : Listener {
     }
 
     /**
-     * Reads a [dialogue] into the track of the given [trackId].
+     * Reads a dialogue into the track of the given [trackId].
      */
-    fun readTrackDialogue(dialogue: String, trackId: String?) {
-        availableTracks[trackId]?.readBuffer(dialogue)
+    fun readTrackDialogue(
+        trackId: String?,
+        start: Long,
+        duration: Long,
+        data: ByteArray,
+        offset: Int = 0,
+        length: Int = data.size
+    ) {
+        availableTracks[trackId]?.readChunk(start, duration, data, offset, length)
     }
 
     /**

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/extractor/AssMatroskaExtractor.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/extractor/AssMatroskaExtractor.kt
@@ -1,6 +1,7 @@
 package io.github.peerless2012.ass.extractor
 
 import androidx.annotation.OptIn
+import androidx.media3.common.util.ParsableByteArray
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.extractor.ExtractorInput
 import androidx.media3.extractor.ExtractorOutput
@@ -8,7 +9,6 @@ import androidx.media3.extractor.mkv.EbmlProcessor
 import androidx.media3.extractor.mkv.MatroskaExtractor
 import androidx.media3.extractor.text.SubtitleParser
 import io.github.peerless2012.ass.AssHandler
-import io.github.peerless2012.ass.kt.Ass
 import io.github.peerless2012.ass.text.AssSubtitleExtractorOutput
 
 @OptIn(UnstableApi::class)
@@ -19,6 +19,8 @@ class AssMatroskaExtractor(
 
     private var currentAttachmentName: String? = null
     private var currentAttachmentMime: String? = null
+
+    internal val subtitleSample = subtitleSampleField.get(this) as ParsableByteArray
 
     override fun getElementType(id: Int): Int {
         return when (id) {
@@ -43,7 +45,7 @@ class AssMatroskaExtractor(
                     if (currentExtractor !is AssSubtitleExtractorOutput) {
                         extractorOutput.set(
                             this,
-                            AssSubtitleExtractorOutput(currentExtractor, assHandler)
+                            AssSubtitleExtractorOutput(currentExtractor, assHandler, this)
                         )
                     }
                 }
@@ -122,6 +124,9 @@ class AssMatroskaExtractor(
         )
 
         val extractorOutput = MatroskaExtractor::class.java.getDeclaredField("extractorOutput").apply {
+            isAccessible = true
+        }
+        val subtitleSampleField = MatroskaExtractor::class.java.getDeclaredField("subtitleSample").apply {
             isAccessible = true
         }
     }

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/parser/AssHeaderParser.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/parser/AssHeaderParser.kt
@@ -6,7 +6,26 @@ import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
 object AssHeaderParser {
-    fun parse(format: Format): ByteArray {
+    /**
+     * Parses the headers from the initialization data of the given [format]. The behavior of this
+     * method depends on the value of [useOriginalHeaders]:
+     *
+     * - If [useOriginalHeaders] is true, the original headers are returned without modification.
+     * - If [useOriginalHeaders] is false, the headers are adjusted to ensure compatibility with
+     *   ExoPlayer's native subtitle renderer.
+     *
+     * ExoPlayer's subtitle renderer modifies the "Format:" line in the headers to include the line
+     * number for duplicate checking. When using it, this method overrides the original "Format:"
+     * line with the updated version provided by ExoPlayer.
+     *
+     * When the effects overlay is used, duplication checks are handled by libass, so the original
+     * headers are preserved.
+     */
+    fun parse(format: Format, useOriginalHeaders: Boolean): ByteArray {
+        if (useOriginalHeaders) {
+            return format.initializationData[1]
+        }
+
         val header1 = format.initializationData[0].decodeToString()
         assert(header1.startsWith("Format:"))
 

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/text/AssSubtitleExtractorOutput.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/text/AssSubtitleExtractorOutput.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.extractor.ExtractorOutput
 import androidx.media3.extractor.TrackOutput
 import io.github.peerless2012.ass.AssHandler
+import io.github.peerless2012.ass.extractor.AssMatroskaExtractor
 
 /**
  * This class is only used by the overlay renderer. It's needed to get the start time of the subtitles.
@@ -13,12 +14,13 @@ import io.github.peerless2012.ass.AssHandler
 class AssSubtitleExtractorOutput(
     private val delegate: ExtractorOutput,
     private val assHandler: AssHandler,
+    private val extractor: AssMatroskaExtractor
 ): ExtractorOutput by delegate {
     override fun track(id: Int, type: Int): TrackOutput {
         return if (type == C.TRACK_TYPE_TEXT) {
             // We can't know at this time if the subtitle track is ASS or other format, so we wrap
             // every subtitle track
-            AssTrackOutput(delegate.track(id, type), assHandler)
+            AssTrackOutput(delegate.track(id, type), assHandler, extractor)
         } else {
             delegate.track(id, type)
         }


### PR DESCRIPTION
With this change, we can finally get rid of the duplicates checking logic in `ASSTrack`. 

There's one more reflection use, but it's only once (when initializing the extractor) so I think that's fine. Also the original headers are passed through to libass, as we don't use the subtitles API for anything on the overlay renderer.

I hope this to be my last PR in a while. I believe this is finally feature complete, and hopefully without any bugs :).