### PR TITLE
Add CI to publish the project to Maven Central Repository + run tests

### DIFF
--- a/.github/actions/setup-libraries/action.yml
+++ b/.github/actions/setup-libraries/action.yml
@@ -1,0 +1,24 @@
+name: Setup Libraries
+description: Runs autogen.sh in required folders
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Running autogen.sh in unibreak
+      run: NOCONFIGURE=1 ./autogen.sh
+      shell: bash
+      working-directory: lib_ass/src/main/cpp/libass-cmake/src/unibreak
+
+    - name: Running autogen.sh in fribidi
+      run: NOCONFIGURE=1 ./autogen.sh
+      shell: bash
+      working-directory: lib_ass/src/main/cpp/libass-cmake/src/fribidi
+
+    - name: Running autogen.sh in ass
+      run: ./autogen.sh
+      shell: bash
+      working-directory: lib_ass/src/main/cpp/libass-cmake/src/ass

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to Maven Central Repository
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: ./.github/actions/setup-libraries
+
+    - name: Publish to Maven Central Repository
+      run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+      env:
+        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USER_NAME }}
+        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+        ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_IN_MEMORY_KEY_ID }}
+        ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  run-tests:
+    name: "Test (${{ matrix.arch }})"
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        arch: ["x86", "x86_64"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: ./.github/actions/setup-libraries
+
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Run tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 21
+        arch: ${{ matrix.arch }}
+        script: ./gradlew test connectedAndroidTest


### PR DESCRIPTION
Tests were executed on nearly all supported Android ABIs, with the exception of `armeabi-v7a`, which is not supported by [reactivecircus/android-emulator-runner](https://github.com/ReactiveCircus/android-emulator-runner). The `arm64-v8a` ABI was also excluded due to the issue described here: https://github.com/ReactiveCircus/android-emulator-runner/issues/404.

The CI workflow for publishing to Maven Central could not be fully tested, as it requires credentials that I do not have access to. You'll need to configure the appropriate credentials in [GitHub Secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions).