### PR TITLE
[app/build.gradle.kts] Add signingConfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     compileOptions {


### PR DESCRIPTION
Without this, I was getting this error when I was trying to run the app in android studio:  The apk for your currently selected variant cannot be signed. Please specify a signing configuration for this variant (release).

![image](https://github.com/user-attachments/assets/c8460cda-314f-4f24-a563-6fbc3742f347)

Note that this is similar to what [media3 does](https://github.com/androidx/media/blob/839c4a90f2ab36e48be73e1b5e907f3283dce72e/demos/main/build.gradle#L43).