### PR TITLE
Add media3 version check when call setZIndex.

### DIFF
--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/parser/AssSubtitleParser.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/parser/AssSubtitleParser.kt
@@ -1,6 +1,7 @@
 package io.github.peerless2012.ass.media.parser
 
 import androidx.media3.common.Format
+import androidx.media3.common.MediaLibraryInfo
 import androidx.media3.common.text.Cue
 import androidx.media3.common.util.Consumer
 import androidx.media3.common.util.UnstableApi
@@ -49,8 +50,12 @@ abstract class AssSubtitleParser(
             val frames = assHandler.render?.renderFrame(event.start + fadeIn, false)
             frames?.images?.let { texts ->
                 texts.forEach { tex ->
-                    val cue = Cue.Builder()
-                        .setZIndex(event.layer)
+                    val cueBuilder = Cue.Builder()
+                    // For users use stable media3
+                    if (MediaLibraryInfo.VERSION_INT > 1_008_000_0_00) {
+                        cueBuilder.setZIndex(event.layer)
+                    }
+                    val cue = cueBuilder
                         .setBitmap(tex.bitmap)
                         .setPosition(tex.x / assHandler.videoSize.width.toFloat())
                         .setPositionAnchor(Cue.ANCHOR_TYPE_START)


### PR DESCRIPTION
Since `media3` 1.8.0 is still on alpha01, for users want to use stable `media3`, for example 1.6.1 or 1.7.1

This commit add a version check before call 1.8.0 new api. 

If app want to use old `media3`, you shoul exclude `media3` lirary from `ass-media`, and force set your `media3` version to 1.6.1 or 1.71.

Note: This check will be removed after 1.8.0 stable is released.