### PR TITLE
Fix ass position when add subtitle on play.

### DIFF
--- a/app/src/main/java/io/github/peerless2012/ass/demo/MainActivity.kt
+++ b/app/src/main/java/io/github/peerless2012/ass/demo/MainActivity.kt
@@ -23,10 +23,11 @@ import com.google.android.material.appbar.MaterialToolbar
 import com.google.common.collect.ImmutableList
 import io.github.peerless2012.ass.media.kt.buildWithAssSupport
 import io.github.peerless2012.ass.media.type.AssRenderType
+import androidx.core.net.toUri
 
 class MainActivity : AppCompatActivity() {
 
-    private var url = "http://192.168.0.254:80/files/c.mkv"
+    private var url = "http://192.168.0.254:80/files/f.mp4"
 
     private lateinit var player: ExoPlayer
 
@@ -54,7 +55,7 @@ class MainActivity : AppCompatActivity() {
             )
         playerView.player = player
         val enConfig = MediaItem.SubtitleConfiguration
-            .Builder(Uri.parse("http://192.168.0.254:80/files/f-en.ass"))
+            .Builder(Uri.parse("http://192.168.0.254:80/files/e.ass"))
             .setMimeType(MimeTypes.TEXT_SSA)
             .setLanguage("en")
             .setLabel("External ass en")
@@ -93,6 +94,28 @@ class MainActivity : AppCompatActivity() {
             R.id.menu_url-> switchUrl()
             R.id.menu_audio -> selectTrack(C.TRACK_TYPE_AUDIO)
             R.id.menu_sub -> selectTrack(C.TRACK_TYPE_TEXT)
+            R.id.menu_sub_add -> {
+                player.currentMediaItem?.let {
+                    val url = "http://192.168.199.138:8080/files/f-d.ass"
+                    val preSubtitleConfigurations = it.localConfiguration?.subtitleConfigurations
+                    if (preSubtitleConfigurations == null || preSubtitleConfigurations.find { it.uri.toString() == url } == null) {
+                        val dynamicConfig = MediaItem.SubtitleConfiguration
+                            .Builder(url.toUri())
+                            .setMimeType(MimeTypes.TEXT_SSA)
+                            .setLanguage("zh-en")
+                            .setLabel("External dynamic ass")
+                            .setId("199")
+                            .build()
+                        val subtitleConfigurations = if (preSubtitleConfigurations == null) {
+                            ImmutableList.of(dynamicConfig)
+                        } else {
+                            ImmutableList.of(dynamicConfig) + preSubtitleConfigurations
+                        }
+                        val newMediaItem = it.buildUpon().setSubtitleConfigurations(subtitleConfigurations).build()
+                        player.setMediaItem(newMediaItem, false)
+                    }
+                }
+            }
             R.id.menu_resize_fit -> playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
             R.id.menu_resize_crop -> playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
         }

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -7,6 +7,8 @@
 
     <item android:id="@+id/menu_sub" android:title="Subtitle"/>
 
+    <item android:id="@+id/menu_sub_add" android:title="Add Subtitle"/>
+
     <group android:id="@+id/menu_resize">
         <item android:id="@+id/menu_resize_fit" android:title="Fit"/>
         <item android:id="@+id/menu_resize_crop" android:title="Crop"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.nonTransitiveRClass=true
 
 # maven publish
 GROUP=io.github.peerless2012
-VERSION_NAME=0.3.0-alpha02
+VERSION_NAME=0.3.0-alpha03
 
 POM_URL=https://github.com/peerless2012/libass-android
 POM_INCEPTION_YEAR=2025

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/AssHandler.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/AssHandler.kt
@@ -148,15 +148,17 @@ class AssHandler(val renderType: AssRenderType) : Listener {
         this.track = track
         val render = requireNotNull(render)
         render.setStorageSize(videoSize.width, videoSize.height)
-        render.setFrameSize(videoSize.width, videoSize.height)
+        if (renderType == AssRenderType.OVERLAY) {
+            render.setFrameSize(surfaceSize.width, surfaceSize.height)
+        } else {
+            render.setFrameSize(videoSize.width, videoSize.height)
+        }
         render.setTrack(track)
 
         // Player func call need in create thread.
         overlayManager?.let {
             handler.post { it.enable(render) }
         }
-
-        renderCallback?.invoke(render)
     }
 
     /**
@@ -170,6 +172,9 @@ class AssHandler(val renderType: AssRenderType) : Listener {
         Log.i("AssHandler", "onSurfaceSizeChanged: width = $width, height = $height")
         if (surfaceSize.width == width && surfaceSize.height == height) return
         surfaceSize = Size(width, height)
+        if (renderType == AssRenderType.OVERLAY && surfaceSize.isValid) {
+            render?.setFrameSize(surfaceSize.width, surfaceSize.height)
+        }
     }
 
     override fun onVideoSizeChanged(videoSize: VideoSize) {
@@ -233,7 +238,17 @@ class AssHandler(val renderType: AssRenderType) : Listener {
             if (videoSize.isValid) {
                 render.setFrameSize(videoSize.width, videoSize.height)
             }
+            if (renderType == AssRenderType.OVERLAY) {
+                if (surfaceSize.isValid) {
+                    render.setFrameSize(surfaceSize.width, surfaceSize.height)
+                }
+            } else {
+                if (videoSize.isValid) {
+                    render.setFrameSize(videoSize.width, videoSize.height)
+                }
+            }
         }
+        renderCallback?.invoke(render)
     }
 
     /**

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleView.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleView.kt
@@ -63,14 +63,6 @@ class AssSubtitleView: View {
         this.assHandler = assHandler
     }
 
-    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
-        super.onSizeChanged(w, h, oldw, oldh)
-        if (assHandler.renderType != AssRenderType.OVERLAY) {
-            return
-        }
-        assHandler.render?.setFrameSize(w, h)
-    }
-
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         if (assHandler.renderType != AssRenderType.OVERLAY) {
@@ -79,12 +71,11 @@ class AssSubtitleView: View {
         assHandler.render?.let {
             assExecutor = AssExecutor(it)
         }
-        assHandler.renderCallback = {
-            if (it == null) {
-                assExecutor?.shutdown()
-                assExecutor = null
-            } else {
-                assExecutor = AssExecutor(it)
+        assHandler.renderCallback = { assRender ->
+            assExecutor?.shutdown()
+            assExecutor = null
+            if (assRender != null) {
+                assExecutor = AssExecutor(assRender)
             }
         }
         assHandler.videoTimeCallback = { presentationTimeUs ->


### PR DESCRIPTION
When player is playing, add subtitle has a wrong frame size. This commit use surface size as frame size when render mode is `OVERLAY`.