### PR TITLE
Use executor instead of executorService, fix memory leaks.

### DIFF
--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/executor/AssExecutor.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/executor/AssExecutor.kt
@@ -59,12 +59,18 @@ class AssExecutor(private val render: AssRender) {
             callback.invoke(assFrameNotChange)
         } else {
             // submit render task
-            executorService.submit{
+            executor.submit{
                 executorBusy = true
-                lastFrame = render.renderFrame(presentationTimeUs / 1000, true)
-                callback.invoke(lastFrame)
-                executorBusy = false
-                lastFrame
+                var result: AssFrame? = null
+                try {
+                    result = render.renderFrame(presentationTimeUs / 1000, true)
+                    lastFrame = result
+                } catch (e: Exception) {
+                    result = null
+                } finally {
+                    executorBusy = false
+                    callback.invoke(result)
+                }
             }
         }
     }


### PR DESCRIPTION
Note: Task in ExecutorCompletionService will not removed if you don't call Feature.get.