### PR TITLE
call ReleaseStringUTFChars to release cName

### DIFF
--- a/lib_ass_kt/src/main/cpp/AssKt.c
+++ b/lib_ass_kt/src/main/cpp/AssKt.c
@@ -59,6 +59,9 @@ void nativeAssAddFont(JNIEnv* env, jclass clazz, jlong ass, jstring name, jbyteA
     const char * cName = (*env)->GetStringUTFChars(env, name, NULL);
     ass_add_font(((ASS_Library *) ass), cName, bytePtr, length);
     (*env)->ReleaseByteArrayElements(env, byteArray, bytePtr, 0);
+    if (cName != NULL) {
+        (*env)->ReleaseStringUTFChars(env, name, cName);
+    }
 }
 
 void nativeAssClearFont(JNIEnv* env, jclass clazz, jlong ass) {


### PR DESCRIPTION
its nessary to call `ReleaseStringUTFChars()` to release the memory obtained using `GetStringUTFChars()`. 