### PR TITLE
Move render to a single task.

### DIFF
--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/executor/AssTask.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/executor/AssTask.kt
@@ -1,0 +1,37 @@
+package io.github.peerless2012.ass.media.executor
+
+import io.github.peerless2012.ass.AssFrame
+import io.github.peerless2012.ass.AssRender
+
+/**
+ * @Author peerless2012
+ * @Email peerless2012@126.com
+ * @DateTime 6/17/25 10:24 PM
+ * @Version V1.0
+ * @Description
+ */
+class AssTask(private val render: AssRender) : Runnable {
+
+    var executorBusy = false
+
+    var presentationTimeUs: Long = 0
+
+    var callback: ((AssFrame?) -> Unit)? = null
+
+    private var lastFrame: AssFrame? = null
+
+    override fun run() {
+        executorBusy = true
+        var result: AssFrame? = null
+        try {
+            result = render.renderFrame(presentationTimeUs / 1000, true)
+            lastFrame = result
+        } catch (e: Exception) {
+            result = null
+        } finally {
+            callback?.invoke(result)
+            executorBusy = false
+            callback = null
+        }
+    }
+}


### PR DESCRIPTION
This will avoid to create a lambda each time render is called.