### PR TITLE
Decrease render call period.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ appcompat = "1.7.1"
 material = "1.12.0"
 activity = "1.10.1"
 constraintlayout = "2.2.1"
-media3 = "1.8.0-alpha01"
+media3 = "1.8.0-beta01"
 publish = "0.31.0"
 
 [libraries]

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/AssHandler.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/AssHandler.kt
@@ -19,6 +19,8 @@ import io.github.peerless2012.ass.Ass
 import io.github.peerless2012.ass.media.parser.AssHeaderParser
 import io.github.peerless2012.ass.media.render.AssOverlayManager
 import io.github.peerless2012.ass.media.type.AssRenderType
+import kotlin.math.floor
+import kotlin.math.roundToInt
 
 /**
  * Handles ASS subtitle rendering and integration with ExoPlayer.
@@ -58,13 +60,25 @@ class AssHandler(val renderType: AssRenderType) : Listener {
     var surfaceSize = Size.ZERO
         private set
 
+    /**  The video frame time. (default is 24fps)  */
+    val videoFramePeriod = 3
+
+    private var videoFrameIndex = 0
+
     var videoTime = -1L
         set(value) {
             if (field == value) {
                 return
             }
             field = value
-            videoTimeCallback?.invoke(value)
+            if (videoFrameIndex == 0) {
+                Log.i("AssHandler", "render = " + videoTime)
+                videoTimeCallback?.invoke(value)
+            }
+            videoFrameIndex++
+            if (videoFrameIndex >= videoFramePeriod) {
+                videoFrameIndex %= videoFramePeriod
+            }
         }
 
     var videoTimeCallback: ((Long) -> Unit)? = null
@@ -102,6 +116,7 @@ class AssHandler(val renderType: AssRenderType) : Listener {
         availableTracks.clear()
         videoSize = Size.ZERO
         videoTime = -1
+        videoFrameIndex = 0
         overlayManager?.disable()
         renderCallback?.invoke(null)
     }

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/AssHandler.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/AssHandler.kt
@@ -72,7 +72,6 @@ class AssHandler(val renderType: AssRenderType) : Listener {
             }
             field = value
             if (videoFrameIndex == 0) {
-                Log.i("AssHandler", "render = " + videoTime)
                 videoTimeCallback?.invoke(value)
             }
             videoFrameIndex++


### PR DESCRIPTION
By default, the render will call each 10ms, this is too short. this change is low down the render call to each 30ms. and will low down the object new and release.