### PR TITLE
Fix texture blending

### DIFF
--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleTextureView.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleTextureView.kt
@@ -211,8 +211,7 @@ class AssSubtitleTextureView : TextureView, AssSubtitleRender, TextureView.Surfa
             uniform vec4 u_Color;
             void main() {
                 float alpha = texture2D(u_Texture, v_TexCoord).a;
-                gl_FragColor = u_Color * alpha;
-
+                gl_FragColor = vec4(u_Color.rgb, u_Color.a * alpha);
             }
         """.trimIndent()
 
@@ -272,9 +271,9 @@ class AssSubtitleTextureView : TextureView, AssSubtitleRender, TextureView.Surfa
             GLES20.glBindBuffer(GLES20.GL_ARRAY_BUFFER, 0)
 
             // enable blend
-            GLES20.glEnable(GLES20.GL_BLEND);
+            GLES20.glEnable(GLES20.GL_BLEND)
             // set blend mode
-            GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
+            GLES20.glBlendFuncSeparate(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA, GLES20.GL_ONE, GLES20.GL_ONE_MINUS_SRC_ALPHA)
         }
 
         override fun onSurfaceChanged(width: Int, height: Int) {


### PR DESCRIPTION
Update blending mode in TextureView to match CanvasView.

Fixes #74

PS: I don't have any experience with graphics/GL, I made the fix with the help of AI, so I'm not 100% sure this is the expected behavior with regards to other players, but this aligns the output (or makes it look very similar) with the CanvasView.