### PR TITLE
fix: DeleteLocalRef for AssEvent in nativeAssTrackGetEvents

### DIFF
--- a/lib_ass_kt/src/main/cpp/AssKt.c
+++ b/lib_ass_kt/src/main/cpp/AssKt.c
@@ -118,6 +118,7 @@ jobjectArray nativeAssTrackGetEvents(JNIEnv* env, jclass clazz, jlong track) {
         (*env)->DeleteLocalRef(env, text);
 
         (*env)->SetObjectArrayElement(env, eventArray, i, javaEvent);
+        (*env)->DeleteLocalRef(env, javaEvent);
     }
     return eventArray;
 }


### PR DESCRIPTION
Fix JNI local reference table overflow (max=512) on Android 7.0 when loading external subtitles with many dialogue events.

Fixes #58