### PR TITLE
fix: check glProgram initialization before delete in onSurfaceDestroyed

### DIFF
--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleTextureView.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleTextureView.kt
@@ -365,7 +365,9 @@ class AssSubtitleTextureView : TextureView, AssSubtitleRender, TextureView.Surfa
         override fun onSurfaceDestroyed() {
             GlUtil.deleteBuffer(vertexBufferId)
             GlUtil.deleteBuffer(texCoordBufferId)
-            glProgram.delete()
+            if (::glProgram.isInitialized) {
+                glProgram.delete()
+            }
         }
 
     }


### PR DESCRIPTION
Guard against UninitializedPropertyAccessException when onSurfaceDestroyed is called before onSurfaceCreated completes (e.g. EGL init failure or rapid view add/remove).

Fixes #75