### PR TITLE
Fix subtitle rendering at wrong size after resize

### DIFF
--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleCanvasView.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleCanvasView.kt
@@ -63,6 +63,13 @@ class AssSubtitleCanvasView : View, AssSubtitleRender {
         this.assHandler = assHandler
     }
 
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        if (w > 0 && h > 0) {
+            assHandler.render?.setFrameSize(w, h)
+        }
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         assHandler.render?.let {

--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleTextureView.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/widget/AssSubtitleTextureView.kt
@@ -112,6 +112,7 @@ class AssSubtitleTextureView : TextureView, AssSubtitleRender, TextureView.Surfa
         private var eglDisplay: EGLDisplay = EGL14.EGL_NO_DISPLAY
         private var eglContext: EGLContext = EGL14.EGL_NO_CONTEXT
         private var eglSurface: EGLSurface = EGL14.EGL_NO_SURFACE
+        private var lastDrawTimestampNanos: Long = 0L
 
         override fun start() {
             super.start()
@@ -126,6 +127,7 @@ class AssSubtitleTextureView : TextureView, AssSubtitleRender, TextureView.Surfa
 
         fun onSurfaceSizeChanged(width: Int, height: Int) {
             this.width = width
+            this.height = height
             handler.sendEmptyMessage(MSG_SURFACE_SIZE_CHANGED)
         }
 
@@ -164,9 +166,17 @@ class AssSubtitleTextureView : TextureView, AssSubtitleRender, TextureView.Surfa
 
         private fun sizeChangedInternal(width: Int, height: Int) {
             render.onSurfaceChanged(width, height)
+            if (eglDisplay != EGL14.EGL_NO_DISPLAY) {
+                GlUtil.clearFocusedBuffers()
+                EGL14.eglSwapBuffers(eglDisplay, eglSurface)
+            }
+            if (lastDrawTimestampNanos != 0L) {
+                drawInternal(lastDrawTimestampNanos)
+            }
         }
 
         private fun drawInternal(timestampNanos: Long) {
+            lastDrawTimestampNanos = timestampNanos
             if (eglDisplay == EGL14.EGL_NO_DISPLAY) return
             if (render.onDrawFrame(timestampNanos)) {
                 EGL14.eglSwapBuffers(eglDisplay, eglSurface)
@@ -233,6 +243,8 @@ class AssSubtitleTextureView : TextureView, AssSubtitleRender, TextureView.Surfa
 
         private var surfaceDirty = true
 
+        private var forceNextRender = false
+
         private var surfaceSize = Size.ZERO
 
         private lateinit var glProgram: GlProgram
@@ -296,6 +308,7 @@ class AssSubtitleTextureView : TextureView, AssSubtitleRender, TextureView.Surfa
             surfaceSize = Size(width, height)
             assHandler.render?.setFrameSize(width, height)
             GLES20.glViewport(0, 0, width, height)
+            forceNextRender = true
         }
 
         override fun onDrawFrame(timestampNanos: Long): Boolean {
@@ -303,7 +316,9 @@ class AssSubtitleTextureView : TextureView, AssSubtitleRender, TextureView.Surfa
             val assFrame = assHandler.render?.renderFrame(timestampNanos / 1000, texType)
 
             // if content not change, just return the tex
-            if (assFrame != null && assFrame.changed == 0) {
+            val force = forceNextRender
+            forceNextRender = false
+            if (assFrame != null && assFrame.changed == 0 && !force) {
                 return false
             }
 


### PR DESCRIPTION
- Fix height not being updated in AssRenderThread.onSurfaceSizeChanged
- Add forceNextRender flag to re-render after resize even when content unchanged
- Flush EGL back buffer on resize to clear stale frame
- Re-render with last timestamp after resize for paused playback
- Add onSizeChanged to AssSubtitleCanvasView to update frame size on resize

Closes #65