### PR TITLE
Fix zlib-compressed ASS dialogue forwarding from Matroska

### DIFF
--- a/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/text/AssTrackOutput.kt
+++ b/lib_ass_media/src/main/java/io/github/peerless2012/ass/media/text/AssTrackOutput.kt
@@ -8,7 +8,10 @@ import androidx.media3.common.util.Util
 import androidx.media3.extractor.TrackOutput
 import io.github.peerless2012.ass.media.AssHandler
 import io.github.peerless2012.ass.media.extractor.AssMatroskaExtractor
+import java.io.ByteArrayOutputStream
 import java.util.regex.Pattern
+import java.util.zip.DataFormatException
+import java.util.zip.Inflater
 
 /**
  * This class is only used by the overlay renderer. It's needed to get the start time of the subtitles.
@@ -46,14 +49,18 @@ class AssTrackOutput(
 
             val rawDuration = sample.data.decodeToString(endIndex, lineIndex - 1)
             val durationUs = parseTimecodeUs(rawDuration)
+            val dialogue = sample.data.dialoguePayload(
+                offset = lineIndex,
+                limit = sample.limit()
+            )
 
             assHandler.readTrackDialogue(
                 trackId = trackId,
                 start = timeUs / 1000,
                 duration = durationUs / 1000,
-                data = sample.data,
-                offset = lineIndex,
-                length = sample.limit() - lineIndex
+                data = dialogue,
+                offset = 0,
+                length = dialogue.size
             )
         }
         delegate.sampleMetadata(timeUs, flags, size, offset, cryptoData)
@@ -83,6 +90,48 @@ class AssTrackOutput(
         return 0
     }
 
+    private fun ByteArray.dialoguePayload(offset: Int, limit: Int): ByteArray {
+        if (offset >= size) return EMPTY_BYTE_ARRAY
+        val boundedLimit = limit.coerceIn(offset, size)
+        val rawEnd = if (looksLikeZlib(offset, size)) size else boundedLimit
+        val rawPayload = copyOfRange(offset, rawEnd)
+        return maybeInflate(rawPayload)
+    }
+
+    private fun ByteArray.looksLikeZlib(offset: Int, limit: Int): Boolean {
+        if (limit - offset < 2) return false
+        val cmf = this[offset].toInt() and 0xFF
+        val flg = this[offset + 1].toInt() and 0xFF
+        return cmf and 0x0F == 8 && ((cmf shl 8) + flg) % 31 == 0
+    }
+
+    private fun maybeInflate(data: ByteArray): ByteArray {
+        if (!data.looksLikeZlib(offset = 0, limit = data.size)) return data
+
+        val inflater = Inflater()
+        return try {
+            inflater.setInput(data)
+            val output = ByteArrayOutputStream(data.size * 4)
+            val buffer = ByteArray(INFLATE_BUFFER_SIZE)
+            while (!inflater.finished()) {
+                val count = inflater.inflate(buffer)
+                if (count > 0) {
+                    output.write(buffer, 0, count)
+                } else if (inflater.needsInput() || inflater.needsDictionary()) {
+                    break
+                } else {
+                    break
+                }
+            }
+            val inflated = output.toByteArray()
+            if (inflater.finished() && inflated.isNotEmpty()) inflated else data
+        } catch (_: DataFormatException) {
+            data
+        } finally {
+            inflater.end()
+        }
+    }
+
     private val Long.isValidTs
         get() = this != C.TIME_UNSET
 
@@ -91,5 +140,7 @@ class AssTrackOutput(
             Pattern.compile("""(?:(\d+):)?(\d+):(\d+)[:.](\d+)""")
 
         const val COMMA = ','.code.toByte()
+        const val INFLATE_BUFFER_SIZE = 4096
+        val EMPTY_BYTE_ARRAY = ByteArray(0)
     }
 }


### PR DESCRIPTION
This fixes ASS/SSA subtitle rendering for Matroska files whose ASS dialogue payloads are zlib-compressed.

The previous overlay path forwarded dialogue bytes using:

```kotlin
data = sample.data
offset = lineIndex
length = sample.limit() - lineIndex
```

That works for plain text ASS payloads, but fails for zlib-compressed payloads. Compressed data may contain embedded NUL bytes, and Media3's subtitle sample limit can represent a truncated text-like slice instead of the full compressed payload. Passing only `sample.limit() - lineIndex` can therefore send an incomplete compressed stream to libass.

## Fix

`AssTrackOutput` now:

- detects zlib-looking dialogue payloads at the ASS dialogue offset,
- copies compressed payloads from the full raw backing buffer,
- inflates them before forwarding to `AssHandler.readTrackDialogue`,
- keeps the previous bounded `sample.limit()` behavior for normal uncompressed ASS payloads,
- falls back to the original bytes if inflation fails.

## Why

Without this, affected fansub MKVs can show symptoms such as:

- missing dialogue lines,
- broken signs/typesetting,
- raw-looking ASS override fragments appearing on screen,
- intermittent subtitle lines because compressed events are truncated before libass receives them.

The important detail is that zlib inflation must use the full raw sample backing buffer / actual block payload, not the truncated `subtitleSample.limit()` slice.

## Scope

This change is limited to the Media3 Matroska ASS forwarding path in:

`lib_ass_media/src/main/java/io/github/peerless2012/ass/media/text/AssTrackOutput.kt`

It does not change renderer selection, overlay behavior, font handling, or normal uncompressed ASS forwarding.

## Testing

This was validated downstream in an app using libass-android with a Matroska sample containing zlib-compressed ASS dialogue packets. Before the fix, dialogue and signs were missing or broken. After inflating from the full raw sample buffer, dialogue, signs, and effects rendered correctly.